### PR TITLE
fix parsing of latitude and longitude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ keywords = ["NMEA", "gps", "glonass", "coordinate", "position"]
 regex = "0.2.1"
 lazy_static = "0.2.2"
 chrono = "0.2.25"
+
+[dev-dependencies]
+quickcheck = "0.3"
+


### PR DESCRIPTION
1. According to NMEA samples, for latitude we have 8 digits,
and for longitude 9 digits. But f32 has only 23 bits for digits, some times
this is not enough, for example 43.33031 -> 4333031 -> 0x421de7 - 24 bits,
so I replace f32 with f64

2. I made mistake, and use round instead of trunc in previous patch,
   so let's fix this bug

3. quickcheck for tests, it helps to me find these bugs